### PR TITLE
UMA をリファクタリング

### DIFF
--- a/ac/config/config.go
+++ b/ac/config/config.go
@@ -176,25 +176,38 @@ func (c *Oauth2ClientCred) to() *clientcredentials.Config {
 
 // UMAClientConf は CAP で UMAClint となるための設定情報
 type UMAClient struct {
-	// 認可サーバの名前
-	AuthZSrvName string `json:"authZ_srv"`
-	// Requesting Party のクレデンシャル情報
 	ReqPartyCredential struct {
-		Name string `json:"name"`
-		Pass string `json:"password"`
-	} `json:"rqp_credential"`
-	// 認可サーバアクセスのためのトークンを OAuth2.0 で
-	Oauth2Conf *Oauth2ResOwnerPass `json:"oauth2"`
+		Iss      string `json:"iss"`
+		Name     string `json:"name"`
+		Password string `json:"password"`
+	} `json:"req_party_credential"`
+	ClientCredential struct {
+		AuthZ  string `json:"authZ"`
+		ID     string `json:"id"`
+		Secret string `json:"secret"`
+	} `json:"client_credential"`
 }
 
 func (c *UMAClient) to() *pip.UMAClientConf {
 	return &pip.UMAClientConf{
-		AuthZSrvName: c.AuthZSrvName,
 		ReqPartyCredential: struct {
-			Name string
-			Pass string
-		}{c.ReqPartyCredential.Name, c.ReqPartyCredential.Pass},
-		Oauth2Conf: c.Oauth2Conf.to(),
+			Issuer string
+			Name   string
+			Pass   string
+		}{
+			Issuer: c.ReqPartyCredential.Iss,
+			Name:   c.ReqPartyCredential.Name,
+			Pass:   c.ReqPartyCredential.Password,
+		},
+		ClientCredential: struct {
+			AuthzSrv string
+			ID       string
+			Secret   string
+		}{
+			AuthzSrv: c.ClientCredential.AuthZ,
+			ID:       c.ClientCredential.ID,
+			Secret:   c.ClientCredential.Secret,
+		},
 	}
 }
 

--- a/actors/rp/cmd/conf.json
+++ b/actors/rp/cmd/conf.json
@@ -41,19 +41,15 @@
               "token_endpoint": "http://idp.ztf-proto.k3.ipv6.mobi/auth/realms/ztf-proto/protocol/openid-connect/token"
             },
             "uma": {
-              "authZ_srv": "http://idp.ztf-proto.k3.ipv6.mobi/auth/realms/ztf-proto",
-              "rqp_credential": {
+              "req_party_credential": {
+                "iss": "http://idp.ztf-proto.k3.ipv6.mobi/auth/realms/ztf-proto",
                 "name": "rp1",
                 "password": "rp1"
               },
-              "oauth2": {
-                "client_id": "rp1",
-                "client_secret": "458e0d6b-64a4-4907-9663-ec876d06f11a",
-                "endpoints": {
-                  "authZ": "http://idp.ztf-proto.k3.ipv6.mobi/auth/realms/ztf-proto/protocol/openid-connect/auth",
-                  "token": "http://idp.ztf-proto.k3.ipv6.mobi/auth/realms/ztf-proto/protocol/openid-connect/token"
-                },
-                "redirect_url": "http://localhost:8080/auth/pip/ctx/0/callback"
+              "client_credential": {
+                "authZ": "http://idp.ztf-proto.k3.ipv6.mobi/auth/realms/ztf-proto",
+                "id": "rp1",
+                "secret": "458e0d6b-64a4-4907-9663-ec876d06f11a"
               }
             }
           }

--- a/uma/client.go
+++ b/uma/client.go
@@ -9,6 +9,63 @@ import (
 	"strings"
 )
 
+// ClientConf はUMAクライアントの設定情報を表す
+type ClientConf struct {
+	AuthZSrv string
+}
+
+// New は設定情報をもとにUMAクライアントを構築する
+// 認可サーバの情報の取得に失敗するとパニック
+// setAuthHeader はRPT要求をする際に Authorization Header を付与する関数
+func (c *ClientConf) New(setAuthHeader func(r *http.Request)) Client {
+	authZSrv, err := NewAuthZSrv(c.AuthZSrv)
+	if err != nil {
+		panic(fmt.Sprintf("uma.Client の構成に失敗(認可サーバの設定を取得できなかった) err: %v", err))
+	}
+	return &cli{
+		authZ:      authZSrv,
+		authHeader: setAuthHeader,
+	}
+}
+
+// Client はUMAクライアントを表す
+type Client interface {
+	ParsePTAndReqRPT(resp *http.Response) (*RPT, error)
+	ReqRPT(pt *PermissionTicket) (*RPT, error)
+}
+
+// ReqRPTError はRPT要求に失敗した時のエラーメッセージを表す
+type ReqRPTError struct {
+	Err            string `json:"error"`
+	ErrDescription string `json:"error_description"`
+	Ticket         string `json:"ticket"`
+}
+
+func (e *ReqRPTError) Error() string {
+	return e.Err + ":" + e.ErrDescription
+}
+
+type cli struct {
+	authZ      *AuthZSrv
+	authHeader func(r *http.Request)
+}
+
+func (c *cli) ParsePTAndReqRPT(resp *http.Response) (*RPT, error) {
+	pt, err := InitialPermissionTicket(resp)
+	if err != nil {
+		return nil, err
+	}
+	return c.ReqRPT(pt)
+}
+
+func (c *cli) ReqRPT(pt *PermissionTicket) (*RPT, error) {
+
+	if pt.InitialOption != nil && c.authZ.Issuer != pt.InitialOption.AuthZSrv {
+		return nil, fmt.Errorf("この許可チケットの発行者に対するクライアントではない")
+	}
+	return ReqRPT(c.authZ.TokenURL, pt.Ticket, c.authHeader)
+}
+
 // InitialPermissionTicket は resp から PermissionTicket を抽出する
 func InitialPermissionTicket(resp *http.Response) (*PermissionTicket, error) {
 	if resp.StatusCode != http.StatusUnauthorized {
@@ -26,22 +83,17 @@ func InitialPermissionTicket(resp *http.Response) (*PermissionTicket, error) {
 		}
 		params[tmp[0]] = strings.ReplaceAll(tmp[1], "\"", "")
 	}
-	return &PermissionTicket{
-		Ticket: params["ticket"],
-		InitialOption: &struct {
-			AuthZSrv string
-			ResSrv   string
-		}{params["as_uri"], params["realms"]},
-	}, nil
+	return NewPermissionTicket(params["ticket"], params["as_uri"], params["realms"]), nil
 }
 
 // ReqRPT は PermissionTicket をもとに RPT を認可サーバに要求する
 // setAuthHeader は認可サーバのトークンエンドポイントにアクセスするための認可情報をリクエストに付与する
 func ReqRPT(tokenURL, ticket string, setAuthHeader func(r *http.Request)) (*RPT, error) {
+	// HTTP Requrst の準備
 	body := url.Values{}
 	body.Set("grant_type", "urn:ietf:params:oauth:grant-type:uma-ticket")
 	body.Add("ticket", ticket)
-	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(body.Encode()))
+	req, err := http.NewRequest(http.MethodPost, tokenURL, strings.NewReader(body.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -51,6 +103,7 @@ func ReqRPT(tokenURL, ticket string, setAuthHeader func(r *http.Request)) (*RPT,
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	contentType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 	if err != nil {
 		return nil, err
@@ -58,37 +111,16 @@ func ReqRPT(tokenURL, ticket string, setAuthHeader func(r *http.Request)) (*RPT,
 	if contentType != "application/json" {
 		return nil, fmt.Errorf("contentType(%v) is not matched with app/json", contentType)
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		e := new(e)
-		if err := json.NewDecoder(resp.Body).Decode(e); err != nil {
+		ee := new(ReqRPTError)
+		if err := json.NewDecoder(resp.Body).Decode(ee); err != nil {
 			return nil, err
 		}
-		return nil, e
-	} else {
-		t := new(RPT)
-		if err := json.NewDecoder(resp.Body).Decode(t); err != nil {
-			return nil, err
-		}
-		return t, nil
+		return nil, ee
 	}
-}
-
-type Error interface {
-	error
-	Hint() string
-}
-
-type e struct {
-	Err            string `json:"error"`
-	ErrDescription string `json:"error_description"`
-	Ticket         string `json:"ticket,omitempty"`
-}
-
-func (e *e) Error() string {
-	return e.Err
-}
-
-func (e *e) Hint() string {
-	return e.ErrDescription
+	t := new(RPT)
+	if err := json.NewDecoder(resp.Body).Decode(t); err != nil {
+		return nil, err
+	}
+	return t, nil
 }

--- a/uma/client.go
+++ b/uma/client.go
@@ -1,37 +1,55 @@
 package uma
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"mime"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 )
 
 // ClientConf はUMAクライアントの設定情報を表す
-type ClientConf struct {
-	AuthZSrv string
+type Conf struct {
+	AuthZSrv   string
+	ClientCred struct {
+		ID     string
+		Secret string
+	}
 }
 
 // New は設定情報をもとにUMAクライアントを構築する
 // 認可サーバの情報の取得に失敗するとパニック
-// setAuthHeader はRPT要求をする際に Authorization Header を付与する関数
-func (c *ClientConf) New(setAuthHeader func(r *http.Request)) Client {
+func (c *Conf) New() Client {
 	authZSrv, err := NewAuthZSrv(c.AuthZSrv)
 	if err != nil {
 		panic(fmt.Sprintf("uma.Client の構成に失敗(認可サーバの設定を取得できなかった) err: %v", err))
 	}
+
+	umaReqs := url.Values{}
+	umaReqs.Set("grant_type", "urn:ietf:params:oauth:grant-type:uma-ticket")
+	umaReqs.Set("ticket", "should-be-replaced")
+	umaReqs.Set("claim_token", "should-be-replaced")
+	umaReqs.Set("claim_token_format", "http://openid.net/specs/openid-connect-core-1_0.html#IDToken")
+	conf := clientcredentials.Config{
+		ClientID:       c.ClientCred.ID,
+		ClientSecret:   c.ClientCred.Secret,
+		TokenURL:       authZSrv.TokenURL,
+		EndpointParams: umaReqs,
+	}
 	return &cli{
-		authZ:      authZSrv,
-		authHeader: setAuthHeader,
+		authZ: authZSrv,
+		conf:  conf,
 	}
 }
 
 // Client はUMAクライアントを表す
 type Client interface {
-	ParsePTAndReqRPT(resp *http.Response) (*RPT, error)
-	ReqRPT(pt *PermissionTicket) (*RPT, error)
+	ExtractPermissionTicket(resp *http.Response) (*PermissionTicket, error)
+	ReqRPT(pt *PermissionTicket, rawidToken string) (*RPT, error)
 }
 
 // ReqRPTError はRPT要求に失敗した時のエラーメッセージを表す
@@ -46,24 +64,54 @@ func (e *ReqRPTError) Error() string {
 }
 
 type cli struct {
-	authZ      *AuthZSrv
-	authHeader func(r *http.Request)
+	authZ *AuthZSrv
+	conf  clientcredentials.Config
 }
 
-func (c *cli) ParsePTAndReqRPT(resp *http.Response) (*RPT, error) {
+func (c *cli) ExtractPermissionTicket(resp *http.Response) (*PermissionTicket, error) {
 	pt, err := InitialPermissionTicket(resp)
 	if err != nil {
 		return nil, err
 	}
-	return c.ReqRPT(pt)
+	if pt.InitialOption.AuthZSrv != c.authZ.Issuer {
+		return nil, fmt.Errorf("sould be equeal Metadata Issuer: %v, resp: %v", c.authZ.Issuer, pt.InitialOption.AuthZSrv)
+	}
+	return pt, nil
 }
 
-func (c *cli) ReqRPT(pt *PermissionTicket) (*RPT, error) {
+func (c *cli) Config(ticket, rawIDToken string) *clientcredentials.Config {
+	ret := c.conf
+	newparams := url.Values{}
+	for k, v := range ret.EndpointParams {
+		switch k {
+		case "ticket":
+			newparams.Set(k, ticket)
+		case "claim_token":
+			newparams.Set(k, rawIDToken)
+		default:
+			newparams[k] = v
+		}
+	}
+	ret.EndpointParams = newparams
+	return &ret
+}
 
+func (c *cli) ReqRPT(pt *PermissionTicket, rawidToken string) (*RPT, error) {
 	if pt.InitialOption != nil && c.authZ.Issuer != pt.InitialOption.AuthZSrv {
 		return nil, fmt.Errorf("この許可チケットの発行者に対するクライアントではない")
 	}
-	return ReqRPT(c.authZ.TokenURL, pt.Ticket, c.authHeader)
+	tok, err := c.Config(pt.Ticket, rawidToken).Token(context.Background())
+	if err != nil {
+		if err, ok := err.(*oauth2.RetrieveError); ok {
+			ee := new(ReqRPTError)
+			if err := json.Unmarshal(err.Body, ee); err != nil {
+				return nil, err
+			}
+			return nil, ee
+		}
+		return nil, err
+	}
+	return &RPT{*tok}, nil
 }
 
 // InitialPermissionTicket は resp から PermissionTicket を抽出する
@@ -84,43 +132,4 @@ func InitialPermissionTicket(resp *http.Response) (*PermissionTicket, error) {
 		params[tmp[0]] = strings.ReplaceAll(tmp[1], "\"", "")
 	}
 	return NewPermissionTicket(params["ticket"], params["as_uri"], params["realms"]), nil
-}
-
-// ReqRPT は PermissionTicket をもとに RPT を認可サーバに要求する
-// setAuthHeader は認可サーバのトークンエンドポイントにアクセスするための認可情報をリクエストに付与する
-func ReqRPT(tokenURL, ticket string, setAuthHeader func(r *http.Request)) (*RPT, error) {
-	// HTTP Requrst の準備
-	body := url.Values{}
-	body.Set("grant_type", "urn:ietf:params:oauth:grant-type:uma-ticket")
-	body.Add("ticket", ticket)
-	req, err := http.NewRequest(http.MethodPost, tokenURL, strings.NewReader(body.Encode()))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	setAuthHeader(req)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	contentType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-	if err != nil {
-		return nil, err
-	}
-	if contentType != "application/json" {
-		return nil, fmt.Errorf("contentType(%v) is not matched with app/json", contentType)
-	}
-	if resp.StatusCode != http.StatusOK {
-		ee := new(ReqRPTError)
-		if err := json.NewDecoder(resp.Body).Decode(ee); err != nil {
-			return nil, err
-		}
-		return nil, ee
-	}
-	t := new(RPT)
-	if err := json.NewDecoder(resp.Body).Decode(t); err != nil {
-		return nil, err
-	}
-	return t, nil
 }


### PR DESCRIPTION
# 変更点
- UMA Client を client credential grant flow で RPT を取得するようにした
- UMA Client が RPT を取得しに行く際、 Requesting Party 情報は token_claim に組み込むことに
あとは色々
